### PR TITLE
Add prefs for saving or setting window position

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 # gnome-shell-extension-firefox-pip
 
-Makes Firefox's Picture-in-Picture windows always on top, automatically.
+Makes Firefox's Picture-in-Picture windows always on top automatically and save or set position.

--- a/extension.js
+++ b/extension.js
@@ -39,6 +39,8 @@ export default class FirefoxPIPExtension extends Extension {
   listenerId = 0;
 
   enable() {
+    this._settings = this.getSettings();
+
     this.listenerId = global.display.connect('window-created', (_, window) =>
       window.get_compositor_private().connect('realize', () =>
         void this.onCreated(window)));
@@ -52,9 +54,31 @@ export default class FirefoxPIPExtension extends Extension {
   onCreated(window) {
     if (FirefoxPIPExtension.isPiP(window)) {
       window.raise_and_make_recent();
-      window.make_above();
-      window.stick();
+
+      if (this._settings.get_boolean("remember-position")) {
+        window.connect('unmanaged', () => {
+          this.onClosed(window);
+        });
+
+        window.move_frame(false, this._settings.get_uint("saved-position-x"), this._settings.get_uint("saved-position-y"));
+      }
+      else if (this._settings.get_boolean("enable-custom-position")) {
+        window.move_frame(false, this._settings.get_uint("custom-position-x"), this._settings.get_uint("custom-position-y"));
+      }
+
+      if (this._settings.get_boolean("always-on-top")) {
+        window.make_above();
+      }
+      if (this._settings.get_boolean("always-on-visible-workspace")) {
+        window.stick();
+      }
     }
+  }
+
+  /** @param {import('@girs/meta-13').Window} window */
+  onClosed(window) {
+    this._settings.set_uint("saved-position-x", window.get_frame_rect().x);
+    this._settings.set_uint("saved-position-y", window.get_frame_rect().y);
   }
 }
 

--- a/metadata.json
+++ b/metadata.json
@@ -6,5 +6,6 @@
     "45"
   ],
   "url": "https://github.com/bennypowers/gnome-shell-extension-firefox-pip",
+  "settings-schema": "org.gnome.shell.extensions.firefox-pip",
   "version": 6
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,0 +1,97 @@
+import Gio from 'gi://Gio';
+import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
+
+import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+export default class FirefoxPIPPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        // Create preferences window
+        const page = new Adw.PreferencesPage({
+            title: _("General"),
+            icon_name: "dialog-information-symbolic",
+        });
+        window.add(page);
+
+        const general_group = new Adw.PreferencesGroup({
+            title: _("General")
+        });
+        page.add(general_group);
+
+        const always_on_top_row = new Adw.SwitchRow({
+            title: _("Always on top")
+        });
+        general_group.add(always_on_top_row);
+
+        const always_on_visible_workspace_row = new Adw.SwitchRow({
+            title: _("Always on visible workspace")
+        });
+        general_group.add(always_on_visible_workspace_row);
+
+        const position_group = new Adw.PreferencesGroup({
+            title: _("Position"),
+            description: _("Set initial position of a PIP window")
+        });
+        page.add(position_group);
+
+        const remember_position_row = new Adw.SwitchRow({
+            title: _("Remember position"),
+        });
+        position_group.add(remember_position_row);
+
+        const custom_position_group = new Adw.PreferencesGroup();
+        page.add(custom_position_group);
+
+        const custom_position_row = new Adw.SwitchRow({
+            title: _("Use custom position")
+        });
+        custom_position_group.add(custom_position_row);
+
+        const custom_position_x_row = new Adw.SpinRow({
+            title: _("Position x:"),
+            adjustment: new Gtk.Adjustment({
+                lower: 0,
+                upper: 8000,
+                page_increment: 100,
+                step_increment: 1,
+            })
+        });
+        custom_position_group.add(custom_position_x_row);
+
+        const custom_position_y_row = new Adw.SpinRow({
+            title: _("Position y:"),
+            adjustment: new Gtk.Adjustment({
+                lower: 0,
+                upper: 8000,
+                page_increment: 100,
+                step_increment: 1,
+            })
+        });
+        custom_position_group.add(custom_position_y_row);
+
+        // Bind settings
+        window._settings = this.getSettings();
+
+        window._settings.bind("always-on-top", always_on_top_row,
+            "active", Gio.SettingsBindFlags.DEFAULT);
+        window._settings.bind("always-on-visible-workspace", always_on_visible_workspace_row,
+            "active", Gio.SettingsBindFlags.DEFAULT);
+
+        window._settings.bind("remember-position", remember_position_row,
+            "active", Gio.SettingsBindFlags.DEFAULT);
+        window._settings.bind("remember-position", custom_position_group,
+            "sensitive", Gio.SettingsBindFlags.INVERT_BOOLEAN);
+
+        window._settings.bind("enable-custom-position", custom_position_row,
+            "active", Gio.SettingsBindFlags.DEFAULT);
+        window._settings.bind("enable-custom-position", custom_position_x_row.get_child(),
+            "sensitive", Gio.SettingsBindFlags.DEFAULT);
+        window._settings.bind("enable-custom-position", custom_position_y_row.get_child(),
+            "sensitive", Gio.SettingsBindFlags.DEFAULT);
+
+        window._settings.bind("custom-position-x", custom_position_x_row,
+            "value", Gio.SettingsBindFlags.DEFAULT);
+        window._settings.bind("custom-position-y", custom_position_y_row,
+            "value", Gio.SettingsBindFlags.DEFAULT);
+    }
+}

--- a/schemas/org.gnome.shell.extensions.firefox-pip.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.firefox-pip.gschema.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+    <schema id="org.gnome.shell.extensions.firefox-pip" path="/org/gnome/shell/extensions/firefox-pip/">
+        <key name="always-on-top" type="b">
+            <default>true</default>
+        </key>
+        <key name="always-on-visible-workspace" type="b">
+            <default>true</default>
+        </key>
+        <key name="remember-position" type="b">
+            <default>false</default>
+        </key>
+        <key name="enable-custom-position" type="b">
+            <default>false</default>
+        </key>
+        <key name="custom-position-x" type="u">
+            <default>50</default>
+        </key>
+        <key name="custom-position-y" type="u">
+            <default>100</default>
+        </key>
+        <key name="saved-position-x" type="u">
+            <default>0</default>
+        </key>
+        <key name="saved-position-y" type="u">
+            <default>0</default>
+        </key>
+    </schema>
+</schemalist>


### PR DESCRIPTION
New try on adding prefs. Didn't get any notification last time the pr was closed or what ever, or I just missed it. Anyway here is about same changes as last time + possibility to save PIP windows position. 

I tried to use .ui file like in the extension you mentioned on last pr, but I didn't manage to get it work. "InternalChildren" from the template didn't bind or something. There is a branch on my fork called "ui_test" if you want to take look.

Again default settings keep the same behavior as before, although I would suggest that the "Remember position" would be enabled by default, I think that is default behavior in many environments. 

Preferences added: 
- Toggle always on top
- Toggle always on visible workspace
- Remember/save position
- Use custom position
